### PR TITLE
Peripheral interrupts defined as enum

### DIFF
--- a/chips/cc26x2/Cargo.toml
+++ b/chips/cc26x2/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
+# enum_primitive-rs original does not have proper nostd compilation at the moment
+num-traits = { version = "0.2", default-features = false }
+enum_primitive = { git = "https://github.com/lthiery/enum_primitive-rs" }

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -2,7 +2,8 @@ use cortexm4::{self, nvic};
 use gpio;
 use i2c;
 use kernel;
-use peripheral_interrupts;
+use num_traits::FromPrimitive;
+use peripheral_interrupts::NVIC_IRQ;
 use rtc;
 use uart;
 
@@ -35,15 +36,17 @@ impl kernel::Chip for Cc26X2 {
     fn service_pending_interrupts(&mut self) {
         unsafe {
             while let Some(interrupt) = nvic::next_pending() {
-                match interrupt {
-                    peripheral_interrupts::GPIO => gpio::PORT.handle_interrupt(),
-                    peripheral_interrupts::AON_RTC => rtc::RTC.handle_interrupt(),
-                    peripheral_interrupts::UART0 => uart::UART0.handle_interrupt(),
-                    peripheral_interrupts::I2C => i2c::I2C0.handle_interrupt(),
+                let irq = NVIC_IRQ::from_u32(interrupt)
+                    .expect("Pending IRQ flag not enumerated in NVIQ_IRQ");
+                match irq {
+                    NVIC_IRQ::GPIO => gpio::PORT.handle_interrupt(),
+                    NVIC_IRQ::AON_RTC => rtc::RTC.handle_interrupt(),
+                    NVIC_IRQ::UART0 => uart::UART0.handle_interrupt(),
+                    NVIC_IRQ::I2C0 => i2c::I2C0.handle_interrupt(),
                     // AON Programmable interrupt
                     // We need to ignore JTAG events since some debuggers emit these
-                    peripheral_interrupts::AON_PROG => (),
-                    _ => panic!("unhandled interrupt {}", interrupt),
+                    NVIC_IRQ::AON_PROG => (),
+                    _ => panic!("Unhandled interrupt {:?}", irq),
                 }
                 let n = nvic::Nvic::new(interrupt);
                 n.clear_pending();

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -6,6 +6,9 @@ extern crate cortexm4;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate kernel;
+#[macro_use]
+extern crate enum_primitive;
+extern crate num_traits;
 
 pub mod aon;
 pub mod chip;

--- a/chips/cc26x2/src/peripheral_interrupts.rs
+++ b/chips/cc26x2/src/peripheral_interrupts.rs
@@ -1,35 +1,41 @@
-#[allow(non_camel_case_types)]
-pub const GPIO: u32 = 0;
-pub const I2C: u32 = 1;
-pub const RF_CORE_PE1: u32 = 2;
-//UNASSIGNED 3
-pub const AON_RTC: u32 = 4;
-pub const UART0: u32 = 5;
-pub const UART1: u32 = 6;
-pub const SSI0: u32 = 7;
-pub const SSI1: u32 = 8;
-pub const RF_CORE_PE2: u32 = 9;
-pub const RF_CORE_HW: u32 = 10;
-pub const RF_CMD_ACK: u32 = 11;
-pub const I2S: u32 = 12;
-//UNASSIGNED 13
-pub const WATCHDOG: u32 = 14;
-pub const GPT0A: u32 = 15;
-pub const GPT0B: u32 = 16;
-pub const GPT1A: u32 = 17;
-pub const GPT1B: u32 = 18;
-pub const GPT2A: u32 = 19;
-pub const GPT2B: u32 = 20;
-pub const GPT3A: u32 = 21;
-pub const GPT3B: u32 = 22;
-pub const CRPYTO: u32 = 23;
-pub const DMA_SW: u32 = 24;
-pub const DMA_ERROR: u32 = 25;
-pub const FLASH: u32 = 26;
-pub const SW_EVENT0: u32 = 27;
-pub const AUX_COMBINED: u32 = 28;
-pub const AON_PROG: u32 = 29;
-pub const DYNAMIC_PROG: u32 = 30;
-pub const AUX_COMP_A: u32 = 31;
-pub const AUX_ADC: u32 = 32;
-pub const TRNG: u32 = 33;
+use num_traits::FromPrimitive;
+
+enum_from_primitive!{
+#[derive(Debug, PartialEq)]
+pub enum NVIC_IRQ {
+    GPIO = 0,
+    I2C0 = 1,
+    RF_CORE_PE1 = 2,
+    //UNASSIGNED 3
+    AON_RTC = 4,
+    UART0 = 5,
+    SSI0 = 7,
+    SSI1 = 8,
+    RF_CORE_PE2 = 9,
+    RF_CORE_HW = 10,
+    RF_CMD_ACK = 11,
+    I2S = 12,
+    //UNASSIGNED 13
+    WATCHDOG = 14,
+    GPT0A = 15,
+    GPT0B = 16,
+    GPT1A = 17,
+    GPT1B = 18,
+    GPT2A = 19,
+    GPT2B = 20,
+    GPT3A = 21,
+    GPT3B = 22,
+    CRPYTO = 23,
+    DMA_SW = 24,
+    DMA_ERROR = 25,
+    FLASH = 26,
+    SW_EVENT0 = 27,
+    AUX_COMBINED = 28,
+    AON_PROG = 29,
+    DYNAMIC_PROG = 30,
+    AUX_COMP_A = 31,
+    AUX_ADC = 32,
+    TRNG = 33,
+    UART1 = 36
+}
+}


### PR DESCRIPTION
### Pull Request Overview

This would make it impossible to accidentally assign the same number twice. Added benefit of expressive prints when IRQ is unhandled.