### PR TITLE
PRCM more canonical use of bitfields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/*
 *.elf
 *.o
 *.ll
+*.lock
 .gdbinit
 
 ## OS X

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -150,19 +150,10 @@ register_bitfields![
         CLK_EN      OFFSET(0) NUMBITS(1) []
     ],
     ClockGate2 [
-        // RESERVED (bits 1-31)
-        AM_EN OFFSET(8) NUMBITS(2) [
-            Set0 = 0b01,
-            Set1 = 0b10,
-            SetAll = 0b11,
-            ClearAll = 0b00
-        ],
-        CLK_EN          OFFSET(0) NUMBITS(2) [
-            Set0 = 0b1,
-            Set1 = 0b10,
-            SetAll = 0b11,
-            ClearAll = 0b0
-        ]
+        CLK_EN0      OFFSET(0) NUMBITS(1) [],
+        CLK_EN1      OFFSET(1) NUMBITS(1) [],
+        AM_EN0       OFFSET(8) NUMBITS(1) [],
+        AM_EN1       OFFSET(9) NUMBITS(1) []
     ],
     PowerDomain0 [
         // RESERVED (bits 3-31)
@@ -382,23 +373,32 @@ impl Clock {
     /// Enables UART clocks for run, sleep and deep sleep mode.
     pub fn enable_uarts() {
         let regs = PRCM_BASE;
-        regs.uart_clk_gate_run.modify(ClockGate2::AM_EN::SetAll);
-        regs.uart_clk_gate_run.modify(ClockGate2::CLK_EN::SetAll);
-        regs.uart_clk_gate_sleep.modify(ClockGate2::CLK_EN::SetAll);
+        regs.uart_clk_gate_run.modify(
+            ClockGate2::AM_EN0::SET
+                + ClockGate2::AM_EN1::SET
+                + ClockGate2::CLK_EN0::SET
+                + ClockGate2::CLK_EN1::SET,
+        );
+        regs.uart_clk_gate_sleep
+            .modify(ClockGate2::CLK_EN0::SET + ClockGate2::CLK_EN1::SET);
         regs.uart_clk_gate_deep_sleep
-            .modify(ClockGate2::CLK_EN::SetAll);
+            .modify(ClockGate2::CLK_EN0::SET + ClockGate2::CLK_EN1::SET);
 
         prcm_commit();
     }
 
     pub fn disable_uarts() {
         let regs = PRCM_BASE;
-        regs.uart_clk_gate_run.modify(ClockGate2::AM_EN::ClearAll);
-        regs.uart_clk_gate_run.modify(ClockGate2::CLK_EN::ClearAll);
+        regs.uart_clk_gate_run.modify(
+            ClockGate2::AM_EN0::CLEAR
+                + ClockGate2::AM_EN1::CLEAR
+                + ClockGate2::CLK_EN0::CLEAR
+                + ClockGate2::CLK_EN1::CLEAR,
+        );
         regs.uart_clk_gate_sleep
-            .modify(ClockGate2::CLK_EN::ClearAll);
+            .modify(ClockGate2::CLK_EN0::CLEAR + ClockGate2::CLK_EN1::CLEAR);
         regs.uart_clk_gate_deep_sleep
-            .modify(ClockGate2::CLK_EN::ClearAll);
+            .modify(ClockGate2::CLK_EN0::CLEAR + ClockGate2::CLK_EN1::CLEAR);
 
         prcm_commit();
     }

--- a/chips/cc26x2/src/radio/subghz.rs
+++ b/chips/cc26x2/src/radio/subghz.rs
@@ -250,8 +250,7 @@ impl radio_client::RadioConfig for Radio {
 pub mod prop_commands {
     #![allow(unused)]
     use kernel::common::registers::ReadOnly;
-    use radio::commands::{RfcTrigger, RfcCondition, RfcSetupConfig};
-    
+    use radio::commands::{RfcCondition, RfcSetupConfig, RfcTrigger};
 
     // Radio and data commands bitfields
     bitfield! {
@@ -290,7 +289,6 @@ pub mod prop_commands {
         pub _whiten_mode, _set_whiten_mode              : 15, 13;
     }
 
-    
     #[repr(C)]
     pub struct CommandCommon {
         pub command_no: ReadOnly<u16>,
@@ -310,7 +308,7 @@ pub mod prop_commands {
         pub start_trigger: u8,
         pub condition: RfcCondition,
         pub modulation: RfcModulation,
-        pub symbol_rate: RfcSymbolRate, 
+        pub symbol_rate: RfcSymbolRate,
         pub rx_bandwidth: u8,
         pub preamble_conf: RfcPreambleConf,
         pub format_conf: RfcFormatConf,

--- a/chips/cc26x2/src/setup/mod.rs
+++ b/chips/cc26x2/src/setup/mod.rs
@@ -111,7 +111,6 @@ pub unsafe extern "C" fn SetupTrimDevice() {
             | 0x2000000usize
             | ((0x40034000i32 + 0x0i32) as (usize) & 0xfffffusize) << 5i32
             | (3i32 << 2i32) as (usize)) as (*mut usize)) != 0 {}
-    
     */
     'loop9: loop {
         if *(((0x40034000i32 + 0x0i32) as (usize) & 0xf0000000usize


### PR DESCRIPTION
My use of bitfields was not very canonical and looks like it was the pattern you copied for AM_EN.

I made them all more canonical - this also fits the Tock pattern so will be easier to upstream.