### PR TITLE
 ,Cc26x2 allow uart1 pins helium pr

### DIFF
--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -143,11 +143,11 @@ unsafe fn configure_pins() {
 
     cc26x2::gpio::PORT[15].enable_gpio();
 
-    cc26x2::gpio::PORT[16].enable_uart1_rx();
-    cc26x2::gpio::PORT[17].enable_uart1_tx();
+    // avoid TDO cc26x2::gpio::PORT[16]
+    // avoid TDI cc26x2::gpio::PORT[17]
 
-    // unused   cc26x2::gpio::PORT[16]
-    // unused   cc26x2::gpio::PORT[17]
+    cc26x2::gpio::PORT[18].enable_uart1_rx();
+    cc26x2::gpio::PORT[19].enable_uart1_tx();
 
     // PWM      cc26x2::gpio::PORT[18]
     // PWM      cc26x2::gpio::PORT[19]

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -122,8 +122,8 @@ unsafe fn configure_pins() {
     cc26x2::gpio::PORT[0].enable_gpio();
     cc26x2::gpio::PORT[1].enable_gpio();
 
-    cc26x2::gpio::PORT[2].enable_uart_rx();
-    cc26x2::gpio::PORT[3].enable_uart_tx();
+    cc26x2::gpio::PORT[2].enable_uart0_rx();
+    cc26x2::gpio::PORT[3].enable_uart0_tx();
 
     cc26x2::gpio::PORT[4].enable_i2c_scl();
     cc26x2::gpio::PORT[5].enable_i2c_sda();
@@ -142,6 +142,9 @@ unsafe fn configure_pins() {
     cc26x2::gpio::PORT[14].enable_gpio();
 
     cc26x2::gpio::PORT[15].enable_gpio();
+
+    cc26x2::gpio::PORT[16].enable_uart1_rx();
+    cc26x2::gpio::PORT[17].enable_uart1_tx();
 
     // unused   cc26x2::gpio::PORT[16]
     // unused   cc26x2::gpio::PORT[17]

--- a/boards/launchxl/src/uart_echo.rs
+++ b/boards/launchxl/src/uart_echo.rs
@@ -24,13 +24,13 @@ const DEFAULT_BAUD: u32 = 115200;
 const MAX_PAYLOAD: usize = 1;
 
 const UART_PARAMS: uart::UARTParameters = uart::UARTParameters {
-            baud_rate: DEFAULT_BAUD,
-            stop_bits: uart::StopBits::One,
-            parity: uart::Parity::None,
-            hw_flow_control: false,
-        };
+    baud_rate: DEFAULT_BAUD,
+    stop_bits: uart::StopBits::One,
+    parity: uart::Parity::None,
+    hw_flow_control: false,
+};
 
-pub static mut OUT_BUF: [u8; MAX_PAYLOAD * 2] = [0; MAX_PAYLOAD + 1];
+pub static mut OUT_BUF: [u8; MAX_PAYLOAD * 2] = [0; MAX_PAYLOAD * 2];
 pub static mut IN_BUF: [u8; MAX_PAYLOAD] = [0; MAX_PAYLOAD];
 
 pub struct UartEcho<U: 'static + UART> {
@@ -56,7 +56,10 @@ impl<U: 'static + UART> UartEcho<U> {
         tx_buf: &'static mut [u8],
         rx_buf: &'static mut [u8],
     ) -> UartEcho<U> {
-        assert!(tx_buf.len() > rx_buf.len(), "UartEcho has improperly sized buffers");
+        assert!(
+            tx_buf.len() > rx_buf.len(),
+            "UartEcho has improperly sized buffers"
+        );
         uart_tx.configure(UART_PARAMS);
         uart_rx.configure(UART_PARAMS);
         UartEcho {

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -39,6 +39,7 @@ impl kernel::Chip for Cc26X2 {
                     peripheral_interrupts::GPIO => gpio::PORT.handle_interrupt(),
                     peripheral_interrupts::AON_RTC => rtc::RTC.handle_interrupt(),
                     peripheral_interrupts::UART0 => uart::UART0.handle_interrupt(),
+                    peripheral_interrupts::UART1 => uart::UART1.handle_interrupt(),
                     peripheral_interrupts::I2C => i2c::I2C0.handle_interrupt(),
                     // AON Programmable interrupt
                     // We need to ignore JTAG events since some debuggers emit these

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -77,7 +77,7 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
     generic_isr,
     generic_isr,
     generic_isr,
-    generic_isr
+    generic_isr,
 ];
 
 #[no_mangle]

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -21,7 +21,7 @@ unsafe extern "C" fn unhandled_interrupt() {
 #[link_section = ".vectors"]
 // used Ensures that the symbol is kept until the final binary
 #[used]
-pub static BASE_VECTORS: [unsafe extern "C" fn(); 50] = [
+pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
     _estack,
     reset_handler,
     unhandled_interrupt, // NMI
@@ -74,6 +74,10 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 50] = [
     generic_isr, // AUX ADC new sample or ADC DMA
     // done, ADC underflow, ADC overflow
     generic_isr, // TRNG event
+    generic_isr,
+    generic_isr,
+    generic_isr,
+    generic_isr
 ];
 
 #[no_mangle]

--- a/chips/cc26x2/src/gpio.rs
+++ b/chips/cc26x2/src/gpio.rs
@@ -224,7 +224,7 @@ impl GPIOPin {
     pub fn enable_uart1_rx(&self) {
         let pin_ioc = &self.ioc_registers.iocfg[self.pin];
 
-        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_RX);
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART1_RX);
         self.set_input_mode(hil::gpio::InputMode::PullNone);
         self.enable_input();
     }
@@ -233,7 +233,7 @@ impl GPIOPin {
     pub fn enable_uart1_tx(&self) {
         let pin_ioc = &self.ioc_registers.iocfg[self.pin];
 
-        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_TX);
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART1_TX);
         self.set_input_mode(hil::gpio::InputMode::PullNone);
         self.enable_output();
     }

--- a/chips/cc26x2/src/gpio.rs
+++ b/chips/cc26x2/src/gpio.rs
@@ -91,12 +91,46 @@ register_bitfields![
             PullNone = 0b11
         ],
         PORT_ID     OFFSET(0) NUMBITS(6) [
-            GPIO = 0x00,
-            UART_RX = 0xF,
-            UART_TX = 0x10,
-            I2C_MSSDA = 0xd,
-            I2C_MSSCL = 0xe
-            // Add more as needed from datasheet p.1028
+            // From p.1072
+            GPIO = 0,
+            AON_CLK32K = 7,
+            AUX_DOMAIN_IO = 8,
+            SSI0_RX = 9,
+            SSI0_TX = 10,
+            SSI0_FSS = 11,
+            SSI0_CLK = 12,
+            I2C_MSSDA = 13,
+            I2C_MSSCL = 14,
+            UART0_RX = 15,
+            UART0_TX = 16,
+            UART0_CTS = 17,
+            UART0_RTS = 18,
+            UART1_RX = 19,
+            UART1_TX = 20,
+            UART1_CTS = 21,
+            UART1_RTS = 22,
+            PORT_EVENT0 = 23,
+            PORT_EVENT1 = 24,
+            PORT_EVENT2 = 25,
+            PORT_EVENT3 = 26,
+            PORT_EVENT4 = 27,
+            PORT_EVENT5 = 28,
+            PORT_EVENT6 = 29,
+            PORT_EVENT7 = 30,
+            CPU_SWV = 32,
+            SSI1_RX = 33,
+            SSI1_TX = 34,
+            SSI1_FSS = 35,
+            SSI1_CLK = 36,
+            I2S_AD0 = 37,
+            I2S_AD1 = 38,
+            I2S_WCLK = 39,
+            I2S_BCLK = 40,
+            I2S_MCLK = 41,
+            RFC_GPO0 = 47,
+            RFC_GPO1 = 48,
+            RFC_GPO2 = 49,
+            RFC_GPO3 = 50
         ]
     ]
 ];
@@ -168,20 +202,38 @@ impl GPIOPin {
         self.enable_input();
     }
 
-    /// Configures pin for UART receive (RX).
-    pub fn enable_uart_rx(&self) {
+    /// Configures pin for UART0 receive (RX).
+    pub fn enable_uart0_rx(&self) {
         let pin_ioc = &self.ioc_registers.iocfg[self.pin];
 
-        pin_ioc.modify(IoConfiguration::PORT_ID::UART_RX);
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_RX);
         self.set_input_mode(hil::gpio::InputMode::PullNone);
         self.enable_input();
     }
 
-    /// Configures pin for UART transmit (TX).
-    pub fn enable_uart_tx(&self) {
+    // Configures pin for UART0 transmit (TX).
+    pub fn enable_uart0_tx(&self) {
         let pin_ioc = &self.ioc_registers.iocfg[self.pin];
 
-        pin_ioc.modify(IoConfiguration::PORT_ID::UART_TX);
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_TX);
+        self.set_input_mode(hil::gpio::InputMode::PullNone);
+        self.enable_output();
+    }
+
+    // Configures pin for UART1 receive (RX).
+    pub fn enable_uart1_rx(&self) {
+        let pin_ioc = &self.ioc_registers.iocfg[self.pin];
+
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_RX);
+        self.set_input_mode(hil::gpio::InputMode::PullNone);
+        self.enable_input();
+    }
+
+    // Configures pin for UART1 transmit (TX).
+    pub fn enable_uart1_tx(&self) {
+        let pin_ioc = &self.ioc_registers.iocfg[self.pin];
+
+        pin_ioc.modify(IoConfiguration::PORT_ID::UART0_TX);
         self.set_input_mode(hil::gpio::InputMode::PullNone);
         self.enable_output();
     }

--- a/chips/cc26x2/src/peripheral_interrupts.rs
+++ b/chips/cc26x2/src/peripheral_interrupts.rs
@@ -5,7 +5,6 @@ pub const RF_CORE_PE1: u32 = 2;
 //UNASSIGNED 3
 pub const AON_RTC: u32 = 4;
 pub const UART0: u32 = 5;
-pub const UART1: u32 = 6;
 pub const SSI0: u32 = 7;
 pub const SSI1: u32 = 8;
 pub const RF_CORE_PE2: u32 = 9;
@@ -33,3 +32,4 @@ pub const DYNAMIC_PROG: u32 = 30;
 pub const AUX_COMP_A: u32 = 31;
 pub const AUX_ADC: u32 = 32;
 pub const TRNG: u32 = 33;
+pub const UART1: u32 = 36;

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -138,7 +138,7 @@ register_bitfields![
     ClockGate2 [
         // RESERVED (bits 1-31)
         CLK0_EN          OFFSET(0) NUMBITS(1) [],
-        CLK1_EN          OFFSET(0) NUMBITS(1) []
+        CLK1_EN          OFFSET(1) NUMBITS(1) []
 
     ],
     PowerDomain0 [

--- a/chips/cc26x2/src/uart.rs
+++ b/chips/cc26x2/src/uart.rs
@@ -109,7 +109,8 @@ struct Transaction {
 pub struct UART {
     registers: &'static StaticRef<UartRegisters>,
     nvic: &'static nvic::Nvic,
-    client: OptionalCell<&'static uart::Client>,
+    tx_client: OptionalCell<&'static uart::Client>,
+    rx_client: OptionalCell<&'static uart::Client>,
     tx: MapCell<Transaction>,
     rx: MapCell<Transaction>,
 }
@@ -154,7 +155,9 @@ impl UART {
             registers,
             nvic,
 
-            client: OptionalCell::empty(),
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+
             tx: MapCell::empty(),
             rx: MapCell::empty(),
         }
@@ -250,7 +253,7 @@ impl UART {
 
         self.rx.take().map(|mut rx| {
             if rx.index == rx.length {
-                self.client.map(move |client| {
+                self.rx_client.map(move |client| {
                     client.receive_complete(
                         rx.buffer,
                         rx.index,
@@ -264,7 +267,7 @@ impl UART {
 
         self.tx.take().map(|mut tx| {
             if tx.index == tx.length {
-                self.client.map(move |client| {
+                self.tx_client.map(move |client| {
                     client.transmit_complete(tx.buffer, kernel::hil::uart::Error::CommandComplete);
                 });
             } else {
@@ -297,11 +300,20 @@ impl UART {
     pub fn tx_fifo_not_full(&self) -> bool {
         !self.registers.fr.is_set(Flags::TX_FIFO_FULL)
     }
+
+    pub fn set_tx_client(&self, client: &'static kernel::hil::uart::Client) {
+        self.tx_client.set(client);
+    }
+
+    pub fn set_rx_client(&self, client: &'static kernel::hil::uart::Client) {
+        self.rx_client.set(client);
+    }
 }
 
 impl kernel::hil::uart::UART for UART {
     fn set_client(&self, client: &'static kernel::hil::uart::Client) {
-        self.client.set(client);
+        self.rx_client.set(client);
+        self.tx_client.set(client);
     }
 
     fn configure(&self, params: kernel::hil::uart::UARTParameters) -> ReturnCode {
@@ -311,7 +323,7 @@ impl kernel::hil::uart::UART for UART {
     fn transmit(&self, buffer: &'static mut [u8], len: usize) {
         // if there is a weird input, don't try to do any transfers
         if len == 0 {
-            self.client.map(move |client| {
+            self.tx_client.map(move |client| {
                 client.transmit_complete(buffer, kernel::hil::uart::Error::CommandComplete);
             });
         } else {
@@ -334,7 +346,7 @@ impl kernel::hil::uart::UART for UART {
 
     fn receive(&self, buffer: &'static mut [u8], len: usize) {
         if len == 0 {
-            self.client.map(move |client| {
+            self.rx_client.map(move |client| {
                 client.receive_complete(buffer, len, kernel::hil::uart::Error::CommandComplete);
             });
         } else {
@@ -351,7 +363,7 @@ impl kernel::hil::uart::UART for UART {
 
     fn abort_receive(&self) {
         self.rx.take().map(|rx| {
-            self.client.map(move |client| {
+            self.rx_client.map(move |client| {
                 client.receive_complete(
                     rx.buffer,
                     rx.index,


### PR DESCRIPTION
Pushed this upstream to Tock already but wanted to merge with our master ASAP

## Pull Request Overview
- extended cc26x2::gpio.rs such that UART1 tx/rx pins could be enabled
- fixed bug in cc26x2::prcm.rs where pin offset was wrong for UART1
- fixed bug in launchxl::uart_echo.rs where static array arithmetic was only half changed
- enabled pins in launchxl::main.rs such that DIO18/19 are routed to UART1
- extended uart_echo for more testing games
## Testing Strategy
Ran uart_echo.rs snippet in main and tested echo on both ports